### PR TITLE
Fixed spelling & updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Keycloak_integration_example
-> **DISCLAMER**: This is a Simple example of a basic installation of keycloack and use with a empty back end api this is not a production redy repo. please consult the Official documentation of [keycloak](https://www.keycloak.org/) to install your own. This example is using keycloak 26.0.6 ; you can use this project to better undersrtand the interconnection of keycloack and a back end api but you will have to createyour own this project is here as an example and will probably not be upgraded. PLEASE DO !
+> **DISCLAMER**: This is a Simple example of a basic installation of keycloack and use with a empty back end api this is not a production redy repo. please consult the Official documentation of [keycloak](https://www.keycloak.org/) to install your own. This example is using keycloak 26.0.6 ; you can use this project to better undersrtand the interconnection of keycloack and a back end api but you will have to create your own this project is here as an example and will probably not be updated. PLEASE DO !
 
 ## Read the README.md in respective directories to install and launch this little example.
 - Keycloak docker [README](./keycloak_docker/)

--- a/keycloak_docker/README.md
+++ b/keycloak_docker/README.md
@@ -1,6 +1,6 @@
 # keycloack docker 
 ## Setup
-- you can change the values in the .env file to your liking 
+- You can change the values in the .env file to your liking 
 ```env
 POSTGRES_DB=keycloak_db
 POSTGRES_USER=keycloak_db_user
@@ -8,15 +8,18 @@ POSTGRES_PASSWORD=keycloak_db_user_password
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=password
 ```
-those are the default values feel free to change them
+Those are the default values feel free to change them
 
-    you can change the values in the docker-compose file your liking like changing the port
+    You can change the values in the docker-compose file your liking like changing the port
 
 
 ## Run the container
-to run the containne simply execute the folowing command
+To run the containne simply execute the folowing command
 ```shell
 $ docker-compose up -d
 ```
-
-## Go to localhost:{choosen_port} to login on to the admin page
+Or if you are using docker compose V2 or newer this
+```shell
+$ docker compose up -d
+```
+## Go to localhost:{choosen_port} to login on to the admin page (defaults to 8080)

--- a/rest_api_java/README.md
+++ b/rest_api_java/README.md
@@ -1,6 +1,6 @@
 # Spring boot java Rest API
 ## config
-in the /com.test_keycloack_rest_api_java/src/main/resources/application.properties 
+In the /com.test_keycloack_rest_api_java/src/main/resources/application.properties 
 modify the variables according tou your keycloak config :
 ```properties
 keycloak.port=8080
@@ -13,7 +13,7 @@ jwt.auth.converter.resource-id=yourKeycloakclientID
 jwt.auth.converter.principle-attribute=preferred_username
 ```
 
-in the /com.test_keycloack_rest_api_java/src/main/java/com/local_test/keycloack/DemoController.java
+In the /com.test_keycloack_rest_api_java/src/main/java/com/local_test/keycloack/DemoController.java
 modify the variables according tou your keycloak config for the desired roles :
 ```java
 @RestController


### PR DESCRIPTION
Fixed spelling in 3 README.md, and updated the README.md file in "keycloak_docker" do accommodate newer version of docker compose and to inform of the default web interface port